### PR TITLE
Add code block and syntax highlight with highlight.js npm (from cdn) package

### DIFF
--- a/src/events/comment.ts
+++ b/src/events/comment.ts
@@ -15,7 +15,8 @@ export class Comments extends EventGenerator {
         repeating information that's obvious from the code itself. Good comments
         describe "why", explain any "magic" values and non-obvious behaviour.
         Below are some examples of good code comments.
-        Respond based on the programming language of the requested code. Unless stated otherwise
+        Respond based on the programming language of the requested code. Unless stated otherwise.
+
         ${CODE_LABEL}
         async getRestaurantById(id: Types.ObjectId): Promise<Result<IRestaurantResponseDTO>> {
             await this.singleclientService.validateContext();
@@ -35,6 +36,8 @@ export class Comments extends EventGenerator {
             );
         }
         ${COMMENT_LABEL}
+        <pre>
+        <code>
         /**
          * Retrieves restaurant information by its ID asynchronously.
          * This function validates the user's context, by checking the user privileges 
@@ -43,6 +46,22 @@ export class Comments extends EventGenerator {
          * @returns A Promise that resolves to a Result object containing an IRestaurantResponseDTO object
          * @throws {ApplicationError} If the user does not have sufficient privileges
          */
+        </code>
+        </pre>
+
+        ${CODE_LABEL}
+        helloWorld(): string {
+          return "Hello World"
+        }
+        ${COMMENT_LABEL}
+        <pre>
+        <code class="language-javascript">
+        /**
+         * Returns a string that has value "Hello World"
+         * @returns string
+        */
+       </code>
+       </pre>
 `;
     return PROMPT;
   }

--- a/src/events/optimize.ts
+++ b/src/events/optimize.ts
@@ -15,8 +15,8 @@ export class OptimizeCode extends EventGenerator {
         Resource Utilization: Examine how the code utilizes system resources such as CPU, I/O operations, or network calls. Propose optimizations to minimize resource overhead and improve overall efficiency.
         Caching and Memoization: Identify computations or function calls that can benefit from caching or memoization. Suggest ways to store and reuse previously computed results to avoid redundant calculations.
         Parallelization and Concurrency: Identify portions of the code that can be parallelized or executed concurrently to leverage multi-core processors or distributed systems. Propose appropriate parallelization techniques or libraries to improve performance.
-        Please provide the optimized code along with explanations for each significant optimization made. Justify how the optimizations improve the code's performance and efficiency. If trade-offs are involved, discuss the benefits and drawbacks of each optimization approach.
-        Respond based on the programming language of the requested code. Unless stated otherwise
+        Please provide the optimized code along with explainations for each significant optimization made. Justify how the optimizations improve the code's performance and efficiency. If trade-offs are involved, discuss the benefits and drawbacks of each optimization approach.
+        Respond based on the programming language of the requested code. Unless stated otherwise.
 `;
     return PROMPT;
   }

--- a/src/webview/chat_css.ts
+++ b/src/webview/chat_css.ts
@@ -1,3 +1,5 @@
+import { codeHighlightCss } from "./code-highlight_atom-one-dark-reasonable";
+
 export const chatCss: string = `
 #chat-container {
     width: 100%;
@@ -94,7 +96,7 @@ body {
     height: 100vh;
     margin: 0;
     padding: 0;
-    font-family: SF Mono;
+    font-family: 'Montserrat', sans-serif;
 }
 
 
@@ -124,7 +126,9 @@ overflow-x: auto;
 background-color: #000;
 }
 
-code {
-color: rgb(97, 175, 239);
-font-size: 14px;
-}`;
+div.code {
+white-space: pre;
+}
+
+${codeHighlightCss}
+`;

--- a/src/webview/chat_html.ts
+++ b/src/webview/chat_html.ts
@@ -7,8 +7,11 @@ export const chartComponent: string = `
 <meta charset="UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <style>
 ${chatCss}
 </style>

--- a/src/webview/chat_js.ts
+++ b/src/webview/chat_js.ts
@@ -56,5 +56,8 @@ window.addEventListener('message', (event) => {
     }else if (message.type === 'user-input'){
         addChatMessage("You", message.message)
     }
+    
+    //call code higlighter function here
+    hljs.highlightAll();
 })
 `;

--- a/src/webview/code-highlight_atom-one-dark-reasonable.ts
+++ b/src/webview/code-highlight_atom-one-dark-reasonable.ts
@@ -1,0 +1,76 @@
+/*
+
+Atom One Dark With support for ReasonML by Gidi Morris, based off work by Daniel Gamage
+
+Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
+
+*/
+
+export const codeHighlightCss: string = `
+.hljs {
+color: #abb2bf;
+background: transparent;
+}
+.hljs-keyword, .hljs-operator {
+color: #F92672;
+}
+.hljs-pattern-match {
+color: #F92672;
+}
+.hljs-pattern-match .hljs-constructor {
+color: #61aeee;
+}
+.hljs-function {
+color: #61aeee;
+}
+.hljs-function .hljs-params {
+color: #A6E22E;
+}
+.hljs-function .hljs-params .hljs-typing {
+color: #FD971F;
+}
+.hljs-module-access .hljs-module {
+color: #7e57c2;
+}
+.hljs-constructor {
+color: #e2b93d;
+}
+.hljs-constructor .hljs-string {
+color: #9CCC65;
+}
+.hljs-comment, .hljs-quote {
+color: #b18eb1;
+font-style: italic;
+}
+.hljs-doctag, .hljs-formula {
+color: #c678dd;
+}
+.hljs-section, .hljs-name, .hljs-selector-tag, .hljs-deletion, .hljs-subst {
+color: #e06c75;
+}
+.hljs-literal {
+color: #56b6c2;
+}
+.hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute, .hljs-meta .hljs-string {
+color: #98c379;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+color: #e6c07b;
+}
+.hljs-attr, .hljs-variable, .hljs-template-variable, .hljs-type, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo, .hljs-number {
+color: #d19a66;
+}
+.hljs-symbol, .hljs-bullet, .hljs-link, .hljs-meta, .hljs-selector-id, .hljs-title {
+color: #61aeee;
+}
+.hljs-emphasis {
+font-style: italic;
+}
+.hljs-strong {
+font-weight: bold;
+}
+.hljs-link {
+text-decoration: underline;
+}`;


### PR DESCRIPTION
Hello Ola, this is Akmal.

PR to solve issue:
#47 

- add css related code for the code highlight which is the code-highlight_atom-one-dark-reasonable.ts file.
- change font from SF Mono to Montserrat for (personally) better text clarity.
- add code 'hljs.highlightAll();' to properly call the code highlight function.

Image reference:
<img width="1442" alt="SCR-20240602-kyvw" src="https://github.com/olasunkanmi-SE/codebuddy/assets/75739105/18fc63c3-d792-436b-b061-26925441b977">
