### PR TITLE
Refactor: Rename AgentEventEmitter to EventEmitter for clarity

### DIFF
--- a/src/agents/base.ts
+++ b/src/agents/base.ts
@@ -1,9 +1,8 @@
 import * as vscode from "vscode";
-import { AgentEventEmitter } from "../emitter/agent-emitter";
-import { IEventPayload } from "../emitter/interface";
+import { EventEmitter } from "../emitter/agent-emitter";
 
 export abstract class BaseAiAgent
-  extends AgentEventEmitter
+  extends EventEmitter
   implements vscode.Disposable
 {
   constructor() {

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -23,7 +23,7 @@ export class Orchestrator extends BaseAiAgent implements vscode.Disposable {
   }
 
   public handleStatus(event: IEventPayload) {
-    this.emitEvent("onQuery", JSON.stringify(event));
+    this.publish("onQuery", JSON.stringify(event));
     console.log(` ${event.message} - ${JSON.stringify(event)}`);
   }
 

--- a/src/emitter/agent-emitter.ts
+++ b/src/emitter/agent-emitter.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { BaseEmitter } from "./emitter";
 import { IAgentEventMap, IEventPayload } from "./interface";
 
-export class AgentEventEmitter extends BaseEmitter<IAgentEventMap> {
+export class EventEmitter extends BaseEmitter<IAgentEventMap> {
   onStatusChange: vscode.Event<IEventPayload> = this.createEvent("onStatus");
   onError: vscode.Event<IEventPayload> = this.createEvent("onError");
   onUpdate: vscode.Event<IEventPayload> = this.createEvent("onUpdate");
@@ -16,7 +16,7 @@ export class AgentEventEmitter extends BaseEmitter<IAgentEventMap> {
    * @param {string} message The message associated with the event (optional).
 
    */
-  emitEvent(eventName: keyof IAgentEventMap, message?: string, data?: any) {
+  publish(eventName: keyof IAgentEventMap, message?: string, data?: any) {
     const payload: IEventPayload = {
       type: eventName,
       message,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { FileUploader } from "./services/file-uploader";
 import { initializeGenerativeAiEnvironment } from "./services/generative-ai-model-manager";
 import { getConfigValue } from "./utils/utils";
 import { Memory } from "./memory/base";
-import { AgentEventEmitter } from "./emitter/agent-emitter";
+import { EventEmitter } from "./emitter/agent-emitter";
 
 const {
   geminiKey,
@@ -47,7 +47,7 @@ const connectDB = async () => {
 };
 
 let quickFixCodeAction: vscode.Disposable;
-let agentEventEmmitter: AgentEventEmitter;
+let agentEventEmmitter: EventEmitter;
 
 export async function activate(context: vscode.ExtensionContext) {
   try {
@@ -147,7 +147,7 @@ export async function activate(context: vscode.ExtensionContext) {
       [explain]: () => explainCode.execute(),
       [pattern]: () => codePattern.uploadFileHandler(),
       [knowledge]: () => knowledgeBase.execute(),
-      [commitMessage]: () => generateCommitMessage.execute("hello"),
+      [commitMessage]: () => generateCommitMessage.execute("commitMessage"),
       [generateCodeChart]: () => codeChartGenerator.execute(),
       [inlineChat]: () => getInLineChat.execute(),
     };
@@ -164,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext) {
       quickFix,
     );
 
-    agentEventEmmitter = new AgentEventEmitter();
+    agentEventEmmitter = new EventEmitter();
 
     const modelConfigurations: {
       [key: string]: {

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -7,7 +7,7 @@ import { formatText } from "../utils/utils";
 import { getWebviewContent } from "../webview/chat";
 
 let _view: vscode.WebviewView | undefined;
-export abstract class BaseWebViewProvider {
+export abstract class BaseWebViewProvider implements vscode.Disposable {
   protected readonly orchestrator: Orchestrator;
   public static readonly viewId = "chatView";
   static webView: vscode.WebviewView | undefined;
@@ -109,7 +109,7 @@ export abstract class BaseWebViewProvider {
     try {
       const response = await this.generateContent(message.message);
       if (response) {
-        this.orchestrator.emitEvent("onQuery", JSON.stringify(response));
+        this.orchestrator.publish("onQuery", JSON.stringify(response));
       }
     } catch (error) {
       this.logger.error("Unable to publish generateContentEvent", error);

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -143,10 +143,10 @@ export class GeminiWebViewProvider extends BaseWebViewProvider {
         prompt: userInput,
         thought: extractedThought,
       };
-      this.orchestrator.emitEvent("onStatus", JSON.stringify(result));
+      this.orchestrator.publish("onStatus", JSON.stringify(result));
       return result;
     } catch (error: any) {
-      this.orchestrator.emitEvent("onError", error);
+      this.orchestrator.publish("onError", error);
       vscode.window.showErrorMessage("Error processing user query");
       this.logger.error(
         "Error generating, queries, thoughts from user query",

--- a/src/services/generative-ai-model-manager.ts
+++ b/src/services/generative-ai-model-manager.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getConfigValue } from "../utils/utils";
-import { AgentEventEmitter } from "../emitter/agent-emitter";
+import { EventEmitter } from "../emitter/agent-emitter";
 
 export const initializeGenerativeAiEnvironment = async (
   context: vscode.ExtensionContext,
@@ -9,7 +9,7 @@ export const initializeGenerativeAiEnvironment = async (
   webViewProviderClass: any,
   subscriptions: vscode.Disposable[],
   quickFixCodeAction: vscode.Disposable,
-  agentEventEmmitter: AgentEventEmitter,
+  agentEventEmmitter: EventEmitter,
 ) => {
   try {
     const apiKey = getConfigValue(key);


### PR DESCRIPTION
- Renames AgentEventEmitter to EventEmitter to improve code readability and reflect its broader usage.
- Updates references to the class name in relevant files (base.ts, orchestrator.ts, extension.ts, generative-ai-model-manager.ts).
- Replaces emitEvent with publish method to represent publishing of events.