### PR TITLE
Refactor(code-indexing): Improve code indexing and context retrieval

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: CI for restaurant
+name: CI Pipeline
 
 on:
   pull_request:

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -11,7 +11,7 @@ export class Orchestrator extends BaseAiAgent implements vscode.Disposable {
     this.disposables.push(
       this.onStatusChange(this.handleStatus.bind(this)),
       this.onPromptGenerated(this.handlePromptGeneratedEvent.bind(this)),
-      this.onError(this.handleError.bind(this)),
+      // this.onError(this.handleError.bind(this)),
     );
   }
 
@@ -31,9 +31,9 @@ export class Orchestrator extends BaseAiAgent implements vscode.Disposable {
     this.publish("onResponse", event.message);
   }
 
-  public handleError(event: IEventPayload) {
-    console.log(`Error: ${event.message}`);
-  }
+  // public handleError(event: IEventPayload) {
+  //   console.log(`Error: ${event.message}`);
+  // }
 
   public dispose(): void {
     this.disposables.forEach((d) => d.dispose());

--- a/src/application/constant.ts
+++ b/src/application/constant.ts
@@ -65,6 +65,7 @@ export enum FSPROPS {
   SRC_DIRECTORY = "src",
   TS_FILE_PATTERN = "**/*.ts",
   TSCONFIG_FILE = "tsconfig.json",
+  NODE_MODULES_PATTERN = "**/node_modules/**",
 }
 
 export const EmbeddingsConfig = {

--- a/src/application/interfaces/ts.code.mapper.interface.ts
+++ b/src/application/interfaces/ts.code.mapper.interface.ts
@@ -105,7 +105,7 @@ export interface ITypeScriptCodeMapper {
    * Builds a hierarchical map of the codebase by traversing TypeScript files
    * and extracting module and class information.
    */
-  buildCodebaseMap(): Promise<ICodebaseMap>;
+  buildCodebaseMap(): Promise<Map<string, string>>;
 
   /**
    * Extracts interface information from a TypeScript interface declaration.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ const {
 
 const connectDB = async () => {
   await dbManager.connect(
-    "file:/Users/olasunkanmioyinlola/Documents/Apps/codebuddy/patterns/aii.db",
+    "file:/Users/olasunkanmi/Documents/Github/codebuddy/patterns/dev.db",
   );
 };
 
@@ -76,10 +76,11 @@ export async function activate(context: vscode.ExtensionContext) {
     // const names = await fileUpload.getFileNames();
     // console.log(files, names);
 
-    // const index = CodeIndexingService.createInstance();
-    // const result = await index.buildFunctionStructureMap();
+    const index = CodeIndexingService.createInstance();
+    // Get each of the folders and call the next line for each
+    const result = await index.buildFunctionStructureMap();
     // await index.insertFunctionsinDB();
-    // console.log(result);
+    console.log(result);
     const {
       comment,
       review,

--- a/src/llms/gemini/gemini.ts
+++ b/src/llms/gemini/gemini.ts
@@ -280,6 +280,7 @@ export class GeminiLLM
 
       return finalResult;
     } catch (error: any) {
+      // Note. Use this approach to return error messages back to the FE
       this.orchestrator.publish(
         "onError",
         "Model not responding at this time, please try again",

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -103,11 +103,6 @@ export abstract class BaseWebViewProvider implements vscode.Disposable {
   public handleModelResponseEvent(event: IEventPayload) {
     this.sendResponse(formatText(event.message), "bot");
   }
-
-  public handleThinkingEvent(event: IEventPayload) {
-    this.sendResponse(formatText(event.message), "bot");
-  }
-
   abstract generateResponse(
     message?: string,
     metaData?: Record<string, any>,

--- a/src/services/code-indexing.ts
+++ b/src/services/code-indexing.ts
@@ -47,6 +47,7 @@ export class CodeIndexingService {
    */
   async buildFunctionStructureMap(): Promise<Partial<IFunctionData>[]> {
     try {
+      // TODO Get all the typescript project compilers information
       const codeATS = await TypeScriptAtsMapper.getInstance();
       if (!codeATS) {
         throw new Error("Failed to get TypeScriptAtsMapper instance");

--- a/src/services/context-retriever.ts
+++ b/src/services/context-retriever.ts
@@ -9,6 +9,7 @@ import { CodeRepository } from "../infrastructure/repository/code";
 import { getGeminiAPIKey } from "../utils/utils";
 import { EmbeddingService } from "./embedding";
 import { WebSearchService } from "./web-search-service";
+import { Orchestrator } from "../agents/orchestrator";
 
 export class ContextRetriever {
   private readonly codeRepository: CodeRepository;
@@ -17,12 +18,14 @@ export class ContextRetriever {
   private readonly logger: Logger;
   private static instance: ContextRetriever;
   private readonly webSearchService: WebSearchService;
+  protected readonly orchestrator: Orchestrator;
   constructor() {
     this.codeRepository = CodeRepository.getInstance();
     const geminiApiKey = getGeminiAPIKey();
     this.embeddingService = new EmbeddingService(geminiApiKey);
     this.logger = new Logger("ContextRetriever");
     this.webSearchService = WebSearchService.getInstance();
+    this.orchestrator = Orchestrator.getInstance();
   }
 
   static initialize() {
@@ -36,6 +39,7 @@ export class ContextRetriever {
     try {
       const embedding = await this.embeddingService.generateEmbedding(input);
       this.logger.info("Retrieving context from DB");
+      // this.orchestrator.publish("onUpdate", "Retrieving context from DB");
       return this.codeRepository.searchSimilarFunctions(
         embedding,
         ContextRetriever.SEARCH_RESULT_COUNT,
@@ -80,8 +84,8 @@ export class ContextRetriever {
 
   async webSearch(query: string) {
     try {
-      const x = Array.isArray(query) ? query.join("") : query;
-      return await this.webSearchService.run(x);
+      const text = Array.isArray(query) ? query.join("") : query;
+      return await this.webSearchService.run(text);
     } catch (error) {
       this.logger.error("Error reading file:", error);
       throw error;

--- a/webviewUi/src/components/botMessage.tsx
+++ b/webviewUi/src/components/botMessage.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import DOMPurify from "dompurify";
-import React from "react";
+import React, { useEffect } from "react";
 
 interface CodeBlockProps {
   language?: string;
@@ -8,13 +9,20 @@ interface CodeBlockProps {
 }
 
 export const BotMessage: React.FC<CodeBlockProps> = ({ language, content }) => {
+  useEffect(() => {
+    const msgHandler = (event: any) => {
+      if (event) {
+        console.log("ee", event);
+      }
+    };
+    window.addEventListener("message", msgHandler);
+  }, []);
   const handleCopy = () => {
     navigator.clipboard.writeText(content);
   };
 
   const sanitizedContent = DOMPurify.sanitize(content);
-  const action = "thinking...";
-
+  const action = "Researching...";
   return (
     <>
       {content.includes("thinking") ? (
@@ -29,10 +37,7 @@ export const BotMessage: React.FC<CodeBlockProps> = ({ language, content }) => {
               Copy
             </button>
           </div>
-          <div
-            className="doc-content"
-            dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-          />
+          <div className="doc-content" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
         </div>
       )}
     </>


### PR DESCRIPTION
- Update CI pipeline name in workflow.yml.
- Remove unused handleError method from Orchestrator.
- Add NODE_MODULES_PATTERN to FSPROPS enum in constant.ts.
- Change return type of buildCodebaseMap method in ITypeScriptCodeMapper interface to Map<string, string>.
- Fix database connection string in extension.ts.
- Remove handleThinkingEvent method from BaseWebViewProvider.
- Implement FileService as a singleton and update TypeScriptAtsMapper to use it.
- Enhance file system interaction and error handling in FileService.
- Implement the class map for codeIndexing