### PR TITLE
Fix hljs for highlighting code.

### DIFF
--- a/src/webview/chat_css.ts
+++ b/src/webview/chat_css.ts
@@ -9,85 +9,86 @@ import { nightOwlCss } from "./themes/night-owl";
 import { stackOverFlowCss } from "./themes/stackoverflow";
 import { tokyoNightCss } from "./themes/tokyo-night";
 
-const fontFamily = getConfigValue("font.family");
-const theme = getConfigValue("chatview.theme");
-const fontSize = getConfigValue("chatview.font.size");
+export function getChatCss() {
+  let fontFamily = getConfigValue("font.family");
+  let theme = getConfigValue("chatview.theme");
+  let fontSize = getConfigValue("chatview.font.size");
 
-let selectedTheme = "";
+  let selectedTheme = "";
 
-switch (theme) {
-  case "Atom One Dark":
-    selectedTheme = oneDarkCss;
-    break;
-  case "Atom One Dark Reasonable":
-    selectedTheme = oneDarkReasonableCss;
-    break;
-  case "Code Pen":
-    selectedTheme = codePenCss;
-    break;
-  case "felipec":
-    selectedTheme = felipecCss;
-    break;
-  case "github dark":
-    selectedTheme = githubDarkDimmed;
-    break;
-  case "ir black":
-    selectedTheme = irBlack;
-    break;
-  case "night owl":
-    selectedTheme = nightOwlCss;
-    break;
-  case "stackoverflow":
-    selectedTheme = stackOverFlowCss;
-    break;
-  case "tokyo night":
-    selectedTheme = tokyoNightCss;
-    break;
-  default:
-    break;
-}
+  switch (theme) {
+    case "Atom One Dark":
+      selectedTheme = oneDarkCss;
+      break;
+    case "Atom One Dark Reasonable":
+      selectedTheme = oneDarkReasonableCss;
+      break;
+    case "Code Pen":
+      selectedTheme = codePenCss;
+      break;
+    case "felipec":
+      selectedTheme = felipecCss;
+      break;
+    case "github dark":
+      selectedTheme = githubDarkDimmed;
+      break;
+    case "ir black":
+      selectedTheme = irBlack;
+      break;
+    case "night owl":
+      selectedTheme = nightOwlCss;
+      break;
+    case "stackoverflow":
+      selectedTheme = stackOverFlowCss;
+      break;
+    case "tokyo night":
+      selectedTheme = tokyoNightCss;
+      break;
+    default:
+      break;
+  }
 
-let selectedFontFamily = "";
+  let selectedFontFamily = "";
 
-switch (fontFamily) {
-  case "SF Mono":
-    selectedFontFamily = '"SF Mono"';
-    break;
-  case "Montserrat":
-    selectedFontFamily = `'Montserrat', sans-serif`;
-    break;
-  case "Space Mono":
-    selectedFontFamily = "Space Mono";
-    break;
-  case "Fira Code":
-    selectedFontFamily = "Fira Code";
-    break;
-  case "Source Code Pro":
-    selectedFontFamily = "Source Code Pro";
-    break;
-  case "JetBrains Mono":
-    selectedFontFamily = "JetBrains Mono";
-    break;
-  case "Roboto Mono":
-    selectedFontFamily = "Roboto Mono";
-    break;
-  case "Ubuntu Mono":
-    selectedFontFamily = "Ubuntu Mono";
-    break;
-  case "IBM Plex Mono":
-    selectedFontFamily = "IBM Plex Mono";
-    break;
-  case "Inconsolata":
-    selectedFontFamily = "Inconsolata";
-    break;
-  case "JetBrains Mono":
-    selectedFontFamily = "JetBrains Mono";
-    break;
-  default:
-    break;
-}
+  switch (fontFamily) {
+    case "SF Mono":
+      selectedFontFamily = '"SF Mono"';
+      break;
+    case "Montserrat":
+      selectedFontFamily = `'Montserrat', sans-serif`;
+      break;
+    case "Space Mono":
+      selectedFontFamily = "Space Mono";
+      break;
+    case "Fira Code":
+      selectedFontFamily = "Fira Code";
+      break;
+    case "Source Code Pro":
+      selectedFontFamily = "Source Code Pro";
+      break;
+    case "JetBrains Mono":
+      selectedFontFamily = "JetBrains Mono";
+      break;
+    case "Roboto Mono":
+      selectedFontFamily = "Roboto Mono";
+      break;
+    case "Ubuntu Mono":
+      selectedFontFamily = "Ubuntu Mono";
+      break;
+    case "IBM Plex Mono":
+      selectedFontFamily = "IBM Plex Mono";
+      break;
+    case "Inconsolata":
+      selectedFontFamily = "Inconsolata";
+      break;
+    case "JetBrains Mono":
+      selectedFontFamily = "JetBrains Mono";
+      break;
+    default:
+      break;
+  }
 
-export const chatCss: string = `
+  return `
 #chat-container {
     width: 100%;
     max-width: 600px;
@@ -295,3 +296,4 @@ div.code {
 
 ${selectedTheme}
 `;
+}

--- a/src/webview/chat_html.ts
+++ b/src/webview/chat_html.ts
@@ -1,5 +1,5 @@
 import { getUri } from "../utils/utils";
-import { chatCss } from "./chat_css";
+// import { chatCss } from "./chat_css";
 import { chatJs } from "./chat_js";
 import * as path from "path";
 import { Webview, Uri } from "vscode";
@@ -35,7 +35,8 @@ export const chartComponent = (webview: Webview, extensionUri: Uri) => {
   return `
 <html lang="en">
 <head>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous" referrerpolicy="no-referrer" charset="utf-8"></script>
+<script>hljs.highlightAll(); console.log("hljs language is: ", hljs.listLanguages());</script>
  <link rel="stylesheet" type="text/css" href="${stylesUri}">
 </head>
 


### PR DESCRIPTION
Hello Ola, I managed to fix hljs to higlight code sent by the AI bot, inside the doc content.
Apparently, I just need to make sure to have useEffect executed when messages states are updated.

I think I also made hljs to be able to highlight code other than typescript, such as golang here, so you could try with other code languages for hljs code highlighting.
Also, I learn a neat trick to make use of hljs imported through script cdn, to be used inside React code, which can prevent web chunks increase when bundled.

Other changes:
- Made use of onDidChangeConfiguration event and listener, so that whenever theme is changed, example from felipec to tokyo night, the vscode extension will post message to React component and then listen for that css style change, then refresh the UI accordingly.

Image references attached.

![Ola_Codebuddy_hljs_Golang](https://github.com/user-attachments/assets/e490a3a2-b907-4309-b83f-366c98e52d95)
![Ola_Codebuddy_hljs_Typescript](https://github.com/user-attachments/assets/c836cf36-a510-4cc6-9d69-684eecd35a41)
![Ola_Codebuddy_hljs_Typescript_theme_felipec](https://github.com/user-attachments/assets/a7b8d2ad-f6da-4c85-8e06-f9423c8fb9a7)
![Ola_Codebuddy_hljs_Typescript_theme_tokyonight](https://github.com/user-attachments/assets/1259112e-19d3-4114-a40d-e2c07e663112)
![FrontendTrick_cdnjs_script](https://github.com/user-attachments/assets/379c3c1e-6979-4a8b-bd63-c965d9bc692a)
![FrontendTrick_cdnjs_script_BigChunks](https://github.com/user-attachments/assets/781197d3-4928-42f6-91a7-bc3386632387)
