### PR TITLE
feat(workspace): Enhance file and directory exclusion during workspac…

### DIFF
--- a/webviewUi/src/components/webview.tsx
+++ b/webviewUi/src/components/webview.tsx
@@ -188,7 +188,6 @@ export const WebviewUI = () => {
             }}
           >
             <div className="textarea-container">
-              <WorkspceSelector onInputChange={handleAttachmentChange} folders={folders} />
               <div className="horizontal-stack">
                 <span className="currenFile">
                   <small>
@@ -197,6 +196,8 @@ export const WebviewUI = () => {
                   </small>
                 </span>
               </div>
+              <WorkspceSelector onInputChange={handleAttachmentChange} folders={folders} />
+
               <VSCodeTextArea
                 value={userInput}
                 onInput={handleTextChange}


### PR DESCRIPTION


- Add logic to exclude specific directories (node_modules, build, .git, dist) and files (package-lock.json, .vscode, .env) during workspace traversal.
- Move the WorkspceSelector component to be rendered after the currenFile component.